### PR TITLE
Fix for Vim 7.4.1608

### DIFF
--- a/autoload/twibill.vim
+++ b/autoload/twibill.vim
@@ -187,7 +187,7 @@ function! s:setup()
       let api = get(self, func_name, "")
       if api == ""
         for key in keys(self)
-          if string(self[key]) == func_name
+          if string(get(self, key)) == func_name
             let api = key
             let self[func_name] = api
             break


### PR DESCRIPTION
Vim 7.4.1577 から、`self[key]` の値が `Funcref` だった場合、`Funcref` の代わりに `Partial` という値を返すようになりました。これは `self` を内包している `Funcref` で、`self` なしで直接関数を呼べます。
そして Vim 7.4.1608 から、`string(partial)` は `"function('Func', {..(self)..})"` のような値を返すようになりました。
今までこの部分は `string(self[key])` の結果の文字列に依存していたため、動かなくなってしまいました。
これを回避するため、`get()` を使い、`Partial` への変換が起きないようにしました。
全てをチェックしたわけではないですが、tweetvim を軽く使ってみた感じだととりあえずは動いているように見えます。
似たような問題がまた起きる可能性があるので、今後 twibill を触る機会がある場合は、`string()` に強く依存した今の構造を見直した方が良いかもしれません。