### PR TITLE
Specify use http1.0 (cURL)

### DIFF
--- a/autoload/twibill/http.vim
+++ b/autoload/twibill/http.vim
@@ -16,7 +16,7 @@ function! twibill#http#get(url, ...)
   if strlen(getdatastr)
     let url .= "?" . getdatastr
   endif
-  let command = 'curl -0 -L -s -k -i '
+  let command = 'curl --http1.1 -L -s -k -i '
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')
@@ -65,7 +65,7 @@ function! twibill#http#stream(url, ...)
   if strlen(getdatastr)
     let url .= "?" . getdatastr
   endif
-  let command = 'curl -0 -L -s -k -i '
+  let command = 'curl --http1.1 -L -s -k -i '
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')
@@ -88,7 +88,7 @@ function! twibill#http#post(ctx, url, query, headdata)
   else
     let postdatastr = postdata
   endif
-  let command = 'curl -0 -L -s -k -i -X '.method
+  let command = 'curl --http1.1 -L -s -k -i -X '.method
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')

--- a/autoload/twibill/http.vim
+++ b/autoload/twibill/http.vim
@@ -16,7 +16,7 @@ function! twibill#http#get(url, ...)
   if strlen(getdatastr)
     let url .= "?" . getdatastr
   endif
-  let command = 'curl -L -s -k -i '
+  let command = 'curl -0 -L -s -k -i '
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')
@@ -65,7 +65,7 @@ function! twibill#http#stream(url, ...)
   if strlen(getdatastr)
     let url .= "?" . getdatastr
   endif
-  let command = 'curl -L -s -k -i '
+  let command = 'curl -0 -L -s -k -i '
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')
@@ -88,7 +88,7 @@ function! twibill#http#post(ctx, url, query, headdata)
   else
     let postdatastr = postdata
   endif
-  let command = 'curl -L -s -k -i -X '.method
+  let command = 'curl -0 -L -s -k -i -X '.method
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')

--- a/autoload/twibill/oauth.vim
+++ b/autoload/twibill/oauth.vim
@@ -88,7 +88,7 @@ function! twibill#oauth#stream(ctx, url, method, ...)
     if strlen(getdatastr)
       let url .= "?" . getdatastr
     endif
-    let command = 'curl -L -s -k -i '
+    let command = 'curl --http1.1 -L -s -k -i '
     let quote = &shellxquote == '"' ?  "'" : '"'
     for key in keys(header)
       if has('win32')
@@ -101,7 +101,7 @@ function! twibill#oauth#stream(ctx, url, method, ...)
     let file = ''
   else
     let postdatastr = twibill#http#encodeURI(query)
-    let command = 'curl -L -s -k -i -X ' . a:method
+    let command = 'curl --http1.1 -L -s -k -i -X ' . a:method
     let quote = &shellxquote == '"' ?  "'" : '"'
     for key in keys(header)
       if has('win32')


### PR DESCRIPTION
(I believe) If `curl --version` contains `nghttp2`, Twitter sends gzip-ed json.
Currently twibill can not deal with gzip-ed json.
Therefore, curl need to specify http1.0/1.1.