### PR TITLE
Fix for Windows

### DIFF
--- a/autoload/twibill/http.vim
+++ b/autoload/twibill/http.vim
@@ -7,6 +7,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:curl = 'curl -q --http1.1 -L -s -k -i '
 
 function! twibill#http#get(url, ...)
   let getdata = a:0 > 0 ? a:000[0] : {}
@@ -16,7 +17,7 @@ function! twibill#http#get(url, ...)
   if strlen(getdatastr)
     let url .= "?" . getdatastr
   endif
-  let command = 'curl --http1.1 -L -s -k -i '
+  let command = s:curl
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')
@@ -65,7 +66,7 @@ function! twibill#http#stream(url, ...)
   if strlen(getdatastr)
     let url .= "?" . getdatastr
   endif
-  let command = 'curl --http1.1 -L -s -k -i '
+  let command = s:curl
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')
@@ -88,7 +89,7 @@ function! twibill#http#post(ctx, url, query, headdata)
   else
     let postdatastr = postdata
   endif
-  let command = 'curl --http1.1 -L -s -k -i -X '.method
+  let command = s:curl . '-X ' . method
   let quote = &shellxquote == '"' ?  "'" : '"'
   for key in keys(headdata)
     if has('win32')

--- a/autoload/twibill/http.vim
+++ b/autoload/twibill/http.vim
@@ -7,7 +7,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:curl = 'curl -q --http1.1 -L -s -k -i '
+let s:curl = 'curl -q --http1.1 -L -N -s -k -i '
 
 function! twibill#http#get(url, ...)
   let getdata = a:0 > 0 ? a:000[0] : {}

--- a/autoload/twibill/oauth.vim
+++ b/autoload/twibill/oauth.vim
@@ -8,6 +8,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:curl = 'curl -q --http1.1 -L -s -k -i '
+
 function! twibill#oauth#request_token(url, ctx, ...)
   let params = a:0 > 0 ? a:000[0] : {}
   let query = {}
@@ -88,7 +90,7 @@ function! twibill#oauth#stream(ctx, url, method, ...)
     if strlen(getdatastr)
       let url .= "?" . getdatastr
     endif
-    let command = 'curl --http1.1 -L -s -k -i '
+    let command = s:curl
     let quote = &shellxquote == '"' ?  "'" : '"'
     for key in keys(header)
       if has('win32')
@@ -101,7 +103,7 @@ function! twibill#oauth#stream(ctx, url, method, ...)
     let file = ''
   else
     let postdatastr = twibill#http#encodeURI(query)
-    let command = 'curl --http1.1 -L -s -k -i -X ' . a:method
+    let command = s:curl . '-X ' . a:method
     let quote = &shellxquote == '"' ?  "'" : '"'
     for key in keys(header)
       if has('win32')

--- a/autoload/twibill/oauth.vim
+++ b/autoload/twibill/oauth.vim
@@ -8,7 +8,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:curl = 'curl -q --http1.1 -L -s -k -i '
+let s:curl = 'curl -q --http1.1 -L -N -s -k -i '
 
 function! twibill#oauth#request_token(url, ctx, ...)
   let params = a:0 > 0 ? a:000[0] : {}


### PR DESCRIPTION
cURL のバッファリングを無効にしないと Windows で TweetVim が期待通りに動作しません。

cURL の出力がバッファリングされていると、vimproc.vim の `read_line()` が 1 行分を読み込む前にタイムアウトしてしまい、不完全な JSON が返されるためツイートが抜け落ちてしまいます。

ついでに `.curlrc` を無効化しました。